### PR TITLE
Fix module link

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -8,7 +8,7 @@ html(lang="en")
     .container
       .page-header: h1 A Simple Stripe Connect PHP example
 
-      p.lead This is a basic Stripe Connect example app built with Node.js, Express and an #[a( href="https://github.com/lelylan/simple-oauth2") OAuth 2.0 client].
+      p.lead This is a basic Stripe Connect example app built with Node.js, Express and an #[a( href="https://github.com/mulesoft/js-client-oauth2") OAuth 2.0 client].
 
       p.lead This integration uses #[a(href="https://stripe.com/docs/connect/standalone-accounts") standalone accounts], so you can either create a new test account using #[a(href="https://stripe.com/docs/testing") some test data], or connect an existing account (in test mode).
 


### PR DESCRIPTION
The module linked on the view ([simple-oauth2](https://github.com/lelylan/simple-oauth2)) is not the one used in node ([client-oauth2](https://github.com/mulesoft/js-client-oauth2)).